### PR TITLE
Make use of augeas::lens to deploy a NetworkManager lens

### DIFF
--- a/files/lenses/networkmanager.aug
+++ b/files/lenses/networkmanager.aug
@@ -1,0 +1,6 @@
+module NetworkManager =
+  autoload xfm
+  (* Same format as Puppet's IniFile *)
+  let lns = Puppet.lns
+  let filter = incl "/etc/NetworkManager/system-connections/*"
+  let xfm = transform lns filter

--- a/files/lenses/test_networkmanager.aug
+++ b/files/lenses/test_networkmanager.aug
@@ -1,0 +1,50 @@
+module Test_NetworkManager =
+
+let conf = "[connection]
+id=wifoobar
+uuid=16fa8830-cf15-4523-8c1f-c6c635246855
+type=802-11-wireless
+
+[802-11-wireless]
+ssid=wifoobar
+mode=infrastructure
+mac-address=11:00:99:33:33:AA
+security=802-11-wireless-security
+
+[802-11-wireless-security]
+key-mgmt=none
+wep-key0=123abc123abc
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=auto\n"
+
+test NetworkManager.lns get conf =
+  { "connection"
+    { "id" = "wifoobar" }
+    { "uuid" = "16fa8830-cf15-4523-8c1f-c6c635246855" }
+    { "type" = "802-11-wireless" }
+    {  }
+  }
+  { "802-11-wireless"
+    { "ssid" = "wifoobar" }
+    { "mode" = "infrastructure" }
+    { "mac-address" = "11:00:99:33:33:AA" }
+    { "security" = "802-11-wireless-security" }
+    {  }
+  }
+  { "802-11-wireless-security"
+    { "key-mgmt" = "none" }
+    { "wep-key0" = "123abc123abc" }
+    {  }
+  }
+  { "ipv4"
+    { "method" = "auto" }
+    {  }
+  }
+  { "ipv6"
+    { "method" = "auto" }
+  }
+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,4 +7,9 @@ class networkmanager {
   package { "network-manager":
     ensure => installed,
   }
+
+  augeas::lens { "networkmanager":
+    lens_source => "puppet:///modules/networkmanager/lenses/networkmanager.aug",
+    test_source => "puppet:///modules/networkmanager/lenses/test_networkmanager.aug",
+  }
 }


### PR DESCRIPTION
Requires to merge https://github.com/camptocamp/puppet-augeas/pull/3 first.
