### PR TITLE
Reload all connection files

### DIFF
--- a/manifests/openconnect.pp
+++ b/manifests/openconnect.pp
@@ -35,5 +35,6 @@ define networkmanager::openconnect (
     group   => 'root',
     mode    => '0600',
     content => template('networkmanager/openconnect.erb'),
+    notify  => Exec['reload nm configuration'],
   }
 }

--- a/manifests/openvpn.pp
+++ b/manifests/openvpn.pp
@@ -40,5 +40,6 @@ define networkmanager::openvpn (
     group   => 'root',
     mode    => '0600',
     content => template('networkmanager/openvpn.erb'),
+    notify  => Exec['reload nm configuration'],
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -8,4 +8,9 @@ class networkmanager::service {
     ensure => $ensure,
     enable => $::networkmanager::enable,
   }
+
+  exec {'reload nm configuration':
+    name        => '/usr/bin/nmcli connection reload',
+    refreshonly => true,
+  }
 }

--- a/manifests/wifi.pp
+++ b/manifests/wifi.pp
@@ -32,6 +32,7 @@ define networkmanager::wifi (
     Ini_setting {
       ensure  => present,
       path    => "/etc/NetworkManager/system-connections/${name}",
+      notify  => Exec['reload nm configuration'],
     }
 
     # section: connection


### PR DESCRIPTION
Network-manager doesn't reload automatically the configuration files if they aren't modified via the nm-applet. This commit execute automatically the command ```nmcli connection reload``` when a configuration file is added or modified by puppet.