### PR TITLE
Update networkmanager

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Resources:
 ###Class: networkmanager
 
 ####`enable`
-Should the service be enabled during boot time ? Defaults to `true`.
+Should the service be enabled during boot time ? Default to `true`.
 
 ####`openconnect_connections`
 A hash of OpenConnect connections to declare.
@@ -74,13 +74,13 @@ A hash of OpenVPN connections to declare.
 A hash of Wifi connections to declare.
 
 ####`start`
-Should the service be started by Puppet. Defaults to `true`.
+Should the service be started by Puppet. Default to `true`.
 
 ####`version`
-The package version to install. Defaults to `present`.
+The package version to install. Default to `present`.
 
 ####`gui`
-The gui packages to install ('gnome', 'kde', or undef). Defaults to `undef`.
+The gui packages to install ('gnome', 'kde', or undef). Default to `undef`.
 
 ###resource: networkmanager::openconnect
 
@@ -91,22 +91,22 @@ Authentication type.
 Whether to autoconnect the VPN.
 
 ####`ensure`
-Should the connection be `present` or `absent`. Defaults to `present`.
+Should the connection be `present` or `absent`. Default to `present`.
 
 ####`gateway`
 The remote host.
 
 ####`id`
-The id of the VPN connection, defaults to `name`.
+The id of the VPN connection, default to `name`.
 
 ####`ipv4_method`
-IPv4 method. Defaults to `auto`.
+IPv4 method. Default to `auto`.
 
 ####`ipv6_method`
-IPv6 method. Defaults to `auto`.
+IPv6 method. Default to `auto`.
 
 ####`never_default`
-Do not use VPN connection as default route. Defaults to `true`.
+Do not use VPN connection as default route. Default to `true`.
 
 ####`user`
 The user who can use the connection.
@@ -132,16 +132,16 @@ Whether to use LZO compression.
 The connection type.
 
 ####`ensure`
-Should the connection be `present` or `absent`. Defaults to `present`.
+Should the connection be `present` or `absent`. Default to `present`.
 
 ####`id`
-The id of the VPN connection. Defaults to `name`.
+The id of the VPN connection. Default to `name`.
 
 ####`ipv4_method`
-IPv4 method. Defaults to `auto`.
+IPv4 method. Default to `auto`.
 
 ####`never_default`
-Do not use VPN connection as default route. Defaults to `true`.
+Do not use VPN connection as default route. Default to `true`.
 
 ####`password_flags`
 The password flags.
@@ -172,13 +172,13 @@ The UUID of the connection. Default to MD5 of `name`.
 ####`eap`
 
 ####`ensure`
-Should the connection be `present` or `absent`. Defaults to `present`.
+Should the connection be `present` or `absent`. Default to `present`.
 
 ####`ipv4_method`
-IPv4 method. Defaults to `auto`.
+IPv4 method. Default to `auto`.
 
 ####`ipv6_method`
-IPv6 method. Defaults to `auto`.
+IPv6 method. Default to `auto`.
 
 ####`key_mgmt`
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ The UUID of the connection. Default to MD5 of `name`.
 ####`ensure`
 Should the connection be `present` or `absent`. Default to `present`.
 
+####`ignore_ca_cert`
+Ignore CA certificate. It will only work if value of eap is `ttls`, `tls` or `peap`. Allowed values: `true` or `false`. Default to `false`.
+
+####`ignore_phase2_ca_cert`
+Ignore phase 2 CA certificate. It will only work if value of eap is `ttls`, `tls` or `peap`. Allowed values: `true` or `false`. Default to `false`.
+
 ####`ipv4_method`
 IPv4 method. Default to `auto`.
 

--- a/manifests/wifi.pp
+++ b/manifests/wifi.pp
@@ -139,4 +139,26 @@ define networkmanager::wifi (
 
   }
 
+  if ( $eap =~ /^tls|^ttls|^peap/ ) {
+    file { "${directory}/org.gnome.nm-applet.eap.gschema.xml":
+      ensure  => file,
+      content => template('networkmanager/org.gnome.nm-applet.eap.gschema.xml.erb'),
+    } ~>
+    exec { 'Compile modifications':
+      command     => "/usr/bin/glib-compile-schemas ${directory}",
+      refreshonly => true,
+    }
+
+    exec {"sudo -u ${user} DISPLAY=:0 gsettings set org.gnome.nm-applet.eap.${uuid} ignore-ca-cert ${ignore_ca_cert}":
+      unless  => "[ $(sudo -u ${user} DISPLAY=:0 gsettings get org.gnome.nm-applet.eap.${uuid} ignore-ca-cert) = ${ignore_ca_cert} ]",
+      path    => '/usr/bin/',
+      require => File["${directory}/org.gnome.nm-applet.eap.gschema.xml"],
+    }
+
+    exec {"sudo -u ${user} DISPLAY=:0 gsettings set org.gnome.nm-applet.eap.${uuid} ignore-phase2-ca-cert ${ignore_phase2_ca_cert}":
+      unless  => "[ $(sudo -u ${user} DISPLAY=:0 gsettings get org.gnome.nm-applet.eap.${uuid} ignore-phase2-ca-cert) = ${ignore_phase2_ca_cert} ]",
+      path    => '/usr/bin/',
+      require => File["${directory}/org.gnome.nm-applet.eap.gschema.xml"],
+    }
+  }
 }

--- a/templates/org.gnome.nm-applet.eap.gschema.xml.erb
+++ b/templates/org.gnome.nm-applet.eap.gschema.xml.erb
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+  <schema id="org.gnome.nm-applet.eap.<%= @uuid %>" path="/org/gnome/nm-applet/eap/<%= @uuid %>/">
+    <key name="ignore-ca-cert" type="b">
+      <default>false</default>
+      <summary>Ignore CA certificate</summary>
+      <description>Set this to true to disable warnings about CA certificates in EAP authentication.</description>
+    </key>
+    <key name="ignore-phase2-ca-cert" type="b">
+      <default>false</default>
+      <summary>Ignore CA certificate</summary>
+      <description>Set this to true to disable warnings about CA certificates in phase 2 of EAP authentication.</description>
+    </key>
+  </schema>
+</schemalist>


### PR DESCRIPTION
This PR contains a slightly modification of the README and add two parameters for definition networkmanager::wifi. It's now possible to directly configure ignore-ca-cert and ignore-phase2-ca-cert values.