### PR TITLE
Update networkmanager

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ The UUID of the connection. Default to MD5 of `name`.
 ####`ensure`
 Should the connection be `present` or `absent`. Defaults to `present`.
 
+####`ignore_ca_cert`
+Ignore CA certificate. It will only work if value of eap is `ttls`, `tls` or `peap`. Allowed values: `true` or `false`. Default to `false`.
+
+####`ignore_phase2_ca_cert`
+Ignore phase 2 CA certificate. It will only work if value of eap is `ttls`, `tls` or `peap`. Allowed values: `true` or `false`. Default to `false`.
+
 ####`ipv4_method`
 IPv4 method. Defaults to `auto`.
 

--- a/manifests/wifi.pp
+++ b/manifests/wifi.pp
@@ -143,11 +143,11 @@ define networkmanager::wifi (
   }
 
   if ( $eap =~ /^tls|^ttls|^peap/ ) {
-    file { "${directory}/org.gnome.nm-applet.eap.gschema.xml":
+    file { "${directory}/org.gnome.nm-applet.eap.${uuid}.gschema.xml":
       ensure  => file,
       content => template('networkmanager/org.gnome.nm-applet.eap.gschema.xml.erb'),
     } ~>
-    exec { 'Compile modifications':
+    exec { "Compile modifications for ${uuid}":
       command     => "/usr/bin/glib-compile-schemas ${directory}",
       refreshonly => true,
     }
@@ -155,13 +155,13 @@ define networkmanager::wifi (
     exec {"sudo -u ${user} DISPLAY=:0 gsettings set org.gnome.nm-applet.eap.${uuid} ignore-ca-cert ${ignore_ca_cert}":
       unless  => "[ $(sudo -u ${user} DISPLAY=:0 gsettings get org.gnome.nm-applet.eap.${uuid} ignore-ca-cert) = ${ignore_ca_cert} ]",
       path    => '/usr/bin/',
-      require => File["${directory}/org.gnome.nm-applet.eap.gschema.xml"],
+      require => File["${directory}/org.gnome.nm-applet.eap.${uuid}.gschema.xml"],
     }
 
     exec {"sudo -u ${user} DISPLAY=:0 gsettings set org.gnome.nm-applet.eap.${uuid} ignore-phase2-ca-cert ${ignore_phase2_ca_cert}":
       unless  => "[ $(sudo -u ${user} DISPLAY=:0 gsettings get org.gnome.nm-applet.eap.${uuid} ignore-phase2-ca-cert) = ${ignore_phase2_ca_cert} ]",
       path    => '/usr/bin/',
-      require => File["${directory}/org.gnome.nm-applet.eap.gschema.xml"],
+      require => File["${directory}/org.gnome.nm-applet.eap.${uuid}.gschema.xml"],
     }
   }
 }

--- a/manifests/wifi.pp
+++ b/manifests/wifi.pp
@@ -5,18 +5,21 @@ define networkmanager::wifi (
   $eap,
   $phase2_auth,
   $password_raw_flags,
-  $uuid               = regsubst(
+  $uuid                   = regsubst(
     md5($name), '^(.{8})(.{4})(.{4})(.{4})(.{12})$', '\1-\2-\3-\4-\5'),
-  $ensure             = present,
-  $mode               = 'infrastructure',
-  $mac_address        = undef,
-  $autoconnect        = true,
-  $ipv4_method        = 'auto',
-  $ipv6_method        = 'auto',
-  $security           = 'none',
-  $nma_ca_cert_ignore = false,
-  $key_mgmt           = 'wpa-eap',
-  $auth_alg           = 'open',
+  $ensure                 = present,
+  $mode                   = 'infrastructure',
+  $mac_address            = undef,
+  $autoconnect            = true,
+  $ipv4_method            = 'auto',
+  $ipv6_method            = 'auto',
+  $security               = 'none',
+  $nma_ca_cert_ignore     = false,
+  $key_mgmt               = 'wpa-eap',
+  $auth_alg               = 'open',
+  $directory              = '/usr/share/glib-2.0/schemas',
+  $ignore_ca_cert         = false,
+  $ignore_phase2_ca_cert  = false,
 ) {
 
   Class['networkmanager::install'] -> Networkmanager::Wifi[$title]
@@ -139,4 +142,26 @@ define networkmanager::wifi (
 
   }
 
+  if ( $eap =~ /^tls|^ttls|^peap/ ) {
+    file { "${directory}/org.gnome.nm-applet.eap.gschema.xml":
+      ensure  => file,
+      content => template('networkmanager/org.gnome.nm-applet.eap.gschema.xml.erb'),
+    } ~>
+    exec { 'Compile modifications':
+      command     => "/usr/bin/glib-compile-schemas ${directory}",
+      refreshonly => true,
+    }
+
+    exec {"sudo -u ${user} DISPLAY=:0 gsettings set org.gnome.nm-applet.eap.${uuid} ignore-ca-cert ${ignore_ca_cert}":
+      unless  => "[ $(sudo -u ${user} DISPLAY=:0 gsettings get org.gnome.nm-applet.eap.${uuid} ignore-ca-cert) = ${ignore_ca_cert} ]",
+      path    => '/usr/bin/',
+      require => File["${directory}/org.gnome.nm-applet.eap.gschema.xml"],
+    }
+
+    exec {"sudo -u ${user} DISPLAY=:0 gsettings set org.gnome.nm-applet.eap.${uuid} ignore-phase2-ca-cert ${ignore_phase2_ca_cert}":
+      unless  => "[ $(sudo -u ${user} DISPLAY=:0 gsettings get org.gnome.nm-applet.eap.${uuid} ignore-phase2-ca-cert) = ${ignore_phase2_ca_cert} ]",
+      path    => '/usr/bin/',
+      require => File["${directory}/org.gnome.nm-applet.eap.gschema.xml"],
+    }
+  }
 }

--- a/templates/org.gnome.nm-applet.eap.gschema.xml.erb
+++ b/templates/org.gnome.nm-applet.eap.gschema.xml.erb
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+  <schema id="org.gnome.nm-applet.eap.<%= @uuid %>" path="/org/gnome/nm-applet/eap/<%= @uuid %>/">
+    <key name="ignore-ca-cert" type="b">
+      <default>false</default>
+      <summary>Ignore CA certificate</summary>
+      <description>Set this to true to disable warnings about CA certificates in EAP authentication.</description>
+    </key>
+    <key name="ignore-phase2-ca-cert" type="b">
+      <default>false</default>
+      <summary>Ignore CA certificate</summary>
+      <description>Set this to true to disable warnings about CA certificates in phase 2 of EAP authentication.</description>
+    </key>
+  </schema>
+</schemalist>


### PR DESCRIPTION
This PR contains a slightly modification of the README and add two parameters for definition networkmanager::wifi. It's now possible to directly configure ignore-ca-cert and ignore-phase2-ca-cert values.