### PR TITLE
RHEL support + Improved OpenVPN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2015-08-21 - Release 0.3.17
+
+Use docker for acceptance tests
+
 ## 2015-06-26 - Release 0.3.16
 
 Fix strict_variables activation with rspec-puppet 2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2016-XX-XX - Release 0.X.X
+
+- Support for RH-based systems
+- Support for almost all openvpn parameters
+- Deprecated $version, $start and $enable
+
 ## 2016-08-18 - Release 0.4.0
 
 Reload all connection files (fix #14)

--- a/README.md
+++ b/README.md
@@ -61,8 +61,44 @@ Resources:
 
 ###Class: networkmanager
 
-####`enable`
-Should the service be enabled during boot time ? Defaults to `true`.
+####`gui`
+The gui packages to install ('gnome', 'kde', or undef). Defaults to `undef`.
+
+####`manage_packages`
+Should packages be installed by puppet? Defaults to `true`.
+
+####`package`
+Package name for NetworkManager. See params.pp for default.
+
+####`package_gui`
+Package name for NetworkManager graphical desktop component. Defaults to `undef`.
+Set this if your `gui` is neither 'gnome' nor 'kde'.
+
+####`package_gui_openvpn`
+Package name for NetworkManager OpenVPN graphical desktop component. Defaults to `undef`.
+Set this if your `gui` is neither 'gnome' nor 'kde'.
+
+####`package_gui_openconnect`
+Package name for NetworkManager OpenConnect graphical desktop component. Defaults to `undef`.
+Set this if your `gui` is neither 'gnome' nor 'kde'.
+
+####`package_ensure`
+The package version to install. Defaults to `present`.
+NOTE: Setting is ignored if `version` is set.
+
+####`manage_service`
+Should puppet manage the NetworkManager service? Defaults to `true`.
+
+####`service`
+Service name for NetworkManager. See params.pp for default.
+
+####`service_enable`
+Should the service be enabled at boot? Defaults to `true`.
+NOTE: Setting is ignored if `enable` is set.
+
+####`service_ensure`
+Should the service be started by puppet? Defaults to `true`.
+NOTE: Setting is ignored if `start` is set.
 
 ####`openconnect_connections`
 A hash of OpenConnect connections to declare.
@@ -73,14 +109,17 @@ A hash of OpenVPN connections to declare.
 ####`wifi_connections`
 A hash of Wifi connections to declare.
 
-####`start`
-Should the service be started by Puppet. Defaults to `true`.
+####`enable` (DEPRECATED)
+Should the service be enabled during boot time ? Defaults to `undef`.
+Use `service_enable` instead. If `enable` is set, `service_enable` is ignored.
 
-####`version`
-The package version to install. Defaults to `present`.
+####`start` (DEPRECATED)
+Should the service be started by Puppet. Defaults to `undef`.
+Use `service_ensure` instead. If `start` is set, `service_ensure` is ignored.
 
-####`gui`
-The gui packages to install ('gnome', 'kde', or undef). Defaults to `undef`.
+####`version` (DEPRECATED)
+The package version to install. Defaults to `undef`.
+Use `package_ensure` instead. If `version` is set, `package_ensure` is ignored.
 
 ###resource: networkmanager::openconnect
 

--- a/README.md
+++ b/README.md
@@ -158,17 +158,59 @@ The xmlconfig for the VPN.
 
 ###resource: networkmanager::openvpn
 
-####`autoconnect`
-Whether to autoconnect the VPN.
+####`remote` (REQUIRED)
+The remote host. Example: 'vpn1.example.com:1194:tcp, vpn2.example.com:1194:udp'
 
-####`ca`
+####`ca` (REQUIRED)
 Path to the CA certificate.
+
+####`user` (DEPRECATED)
+The user who can use the connection. Replaced with `username` and `permitted_user`. If `user` is set, `username` and `permitted_user` are ignored.
+
+####`username`
+The VPN connection login username. NOTE: If `user` is set, this setting is ignored.
+
+####`permitted_user`
+The local system user that is permitted to activate/deactivate/modify the VPN connection. Leave blank to allow access to all system users. NOTE: If `user` is set, this setting is ignored.
+
+####`remote_random`
+Whether to pick a random remote address from the `remote` list when connecting.
+
+####`connection_type`
+The connection type. Can be 'tls', 'password-tls' or 'password'.
+
+####`hmac`
+The OpenVPN 'auth' parameter. Example: 'SHA512'.
+
+####`cipher`
+The OpenVPN 'cipher' parameter. Example: 'AES-256-CBC'.
+
+####`dev_type`
+Device type for the VPN connection. Example: 'tun'.
+
+####`cert`
+Path to the client/host certificate. Required for TLS-based connections.
+
+####`key`
+Path to the client/host private key. Required for TLS-based connections.
+
+####`cert_pass_flags`
+How to obtain private key decryption passphrase? Can be '0' (saved), '1' (use-agent), '2' (never-saved/always-ask), '4' (not-required)
+
+####`password_flags`
+How to obtain password to login to VPN? Can be '0' (saved), '1' (use-agent), '2' (never-saved/always-ask), '4' (not-required)
 
 ####`comp_lzo`
 Whether to use LZO compression.
 
-####`connection_type`
-The connection type.
+####`ta`
+Path to the TLS-AUTH key.
+
+####`ta_dir`
+TLS-AUTH direction. Can be '0' or '1'.
+
+####`uuid`
+The UUID of the connection. Default to MD5 of `name`.
 
 ####`ensure`
 Should the connection be `present` or `absent`. Defaults to `present`.
@@ -176,31 +218,23 @@ Should the connection be `present` or `absent`. Defaults to `present`.
 ####`id`
 The id of the VPN connection. Defaults to `name`.
 
+####`autoconnect`
+Whether to autoconnect the VPN.
+
 ####`ipv4_method`
 IPv4 method. Defaults to `auto`.
 
 ####`never_default`
 Do not use VPN connection as default route. Defaults to `true`.
 
-####`password_flags`
-The password flags.
-
-####`remote`
-The remote host.
-
 ####`routes`
+Add these additional routes when connected.
 
-####`ta`
-Path to the TA key.
+####`dns`
+DNS servers to use when connected.
 
-####`ta_dir`
-Whether to use a ta directory.
-
-####`user`
-The user who can use the connection.
-
-####`uuid`
-The UUID of the connection. Default to MD5 of `name`.
+####`dns_search`
+Add this DNS search domain into local resolver when connected.
 
 ###resource: networkmanager::wifi
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,3 +1,4 @@
+# Class networkmanager::config
 class networkmanager::config {
   validate_hash($::networkmanager::openconnect_connections)
   validate_hash($::networkmanager::openvpn_connections)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,22 +1,28 @@
-class networkmanager(
-  $version = present,
-  $enable  = true,
-  $start   = true,
-  $gui     = undef,
+# Class networkmanager
+class networkmanager (
+  $manage_packages           = $networkmanager::params::manage_packages,
+  $package_ensure            = $networkmanager::params::package_ensure,
+  $manage_service            = $networkmanager::params::manage_service,
+  $service_enable            = $networkmanager::params::service_enable,
+  $service_ensure            = $networkmanager::params::service_ensure,
+  $gui                       = $networkmanager::params::gui,
+  $openconnect_connections   = {},
+  $openvpn_connections       = {},
+  $wifi_connections          = {},
+) inherits networkmanager::params {
 
-  $openconnect_connections = {},
-  $openvpn_connections     = {},
-  $wifi_connections        = {},
-) {
+  include ::stdlib
 
   if $gui != undef {
-    validate_re($gui, ['^gnome', '^kde'])
+    validate_re($gui, ['^gnome$', '^kde$'])
   }
 
-  class { '::networkmanager::install': } ->
-  class { '::networkmanager::service': } ->
-  Class['networkmanager']
+  include ::networkmanager::install
+  include ::networkmanager::config
+  include ::networkmanager::service
 
-  class { '::networkmanager::config': } ->
-  Class['networkmanager']
+  Class['networkmanager::install'] ->
+  Class['networkmanager::config'] ~>
+  Class['networkmanager::service']
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,14 +1,22 @@
 # Class networkmanager
 class networkmanager (
-  $manage_packages           = $networkmanager::params::manage_packages,
-  $package_ensure            = $networkmanager::params::package_ensure,
-  $manage_service            = $networkmanager::params::manage_service,
-  $service_enable            = $networkmanager::params::service_enable,
-  $service_ensure            = $networkmanager::params::service_ensure,
-  $gui                       = $networkmanager::params::gui,
-  $openconnect_connections   = {},
-  $openvpn_connections       = {},
-  $wifi_connections          = {},
+  $version                 = $networkmanager::params::version,
+  $enable                  = $networkmanager::params::enable,
+  $start                   = $networkmanager::params::start,
+  $gui                     = $networkmanager::params::gui,
+  $manage_packages         = $networkmanager::params::manage_packages,
+  $package                 = $networkmanager::params::package,
+  $package_gui             = $networkmanager::params::package_gui,
+  $package_gui_openvpn     = $networkmanager::params::package_gui_openvpn,
+  $package_gui_openconnect = $networkmanager::params::package_gui_openconnect,
+  $package_ensure          = $networkmanager::params::package_ensure,
+  $manage_service          = $networkmanager::params::manage_service,
+  $service                 = $networkmanager::params::service,
+  $service_enable          = $networkmanager::params::service_enable,
+  $service_ensure          = $networkmanager::params::service_ensure,
+  $openconnect_connections = {},
+  $openvpn_connections     = {},
+  $wifi_connections        = {},
 ) inherits networkmanager::params {
 
   include ::stdlib
@@ -16,13 +24,18 @@ class networkmanager (
   if $gui != undef {
     validate_re($gui, ['^gnome$', '^kde$'])
   }
+  if $version {
+    warning('Class ::networkmanager: parameter $version has been deprecated and replaced with $package_ensure.')
+  }
+  if $enable {
+    warning('Class ::networkmanager: parameter $enable has been deprecated and replaced with $service_enable.')
+  }
+  if $start {
+    warning('Class ::networkmanager: parameter $start has been deprecated and replaced with $service_ensure.')
+  }
 
-  include ::networkmanager::install
-  include ::networkmanager::config
-  include ::networkmanager::service
-
-  Class['networkmanager::install'] ->
-  Class['networkmanager::config'] ~>
-  Class['networkmanager::service']
+  class {'::networkmanager::install': } ->
+  class {'::networkmanager::config': } ~>
+  class {'::networkmanager::service': }
 
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,23 +1,14 @@
 # Class networkmanager::install
 class networkmanager::install {
-  include ::networkmanager
-
   if $::networkmanager::manage_packages {
-    package { $::networkmanager::package:
-      ensure => $::networkmanager::package_ensure,
+    $package_ensure = pick($::networkmanager::version, $::networkmanager::package_ensure)
+    $package_gui = $::networkmanager::gui ? {
+      'gnome' => $::networkmanager::params::package_gnome,
+      'kde'   => $::networkmanager::params::package_kde,
+      default => $::networkmanager::package_gui,
     }
-    case $::networkmanager::gui {
-      'gnome': {
-        package { $::networkmanager::package_gnome:
-          ensure => $::networkmanager::package_ensure,
-        }
-      }
-      'kde': {
-        package { $::networkmanager::package_kde:
-          ensure => $::networkmanager::package_ensure,
-        }
-      }
-      default: {}
+    package {[$::networkmanager::package,$package_gui]:
+      ensure => $package_ensure,
     }
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,7 +7,8 @@ class networkmanager::install {
       'kde'   => $::networkmanager::params::package_kde,
       default => $::networkmanager::package_gui,
     }
-    package {[$::networkmanager::package,$package_gui]:
+    $_packages = delete_undef_values([$::networkmanager::package,$package_gui])
+    package { $_packages:
       ensure => $package_ensure,
     }
   }

--- a/manifests/install/openconnect.pp
+++ b/manifests/install/openconnect.pp
@@ -1,19 +1,19 @@
-# Class networkmanager::install
-class networkmanager::install {
+# Class networkmanager::install::openconnect
+class networkmanager::install::openconnect {
   include ::networkmanager
 
   if $::networkmanager::manage_packages {
-    package { $::networkmanager::package:
+    package { $::networkmanager::params::package_openconnect:
       ensure => $::networkmanager::package_ensure,
     }
     case $::networkmanager::gui {
       'gnome': {
-        package { $::networkmanager::package_gnome:
+        package { $::networkmanager::params::package_openconnect_gnome:
           ensure => $::networkmanager::package_ensure,
         }
       }
       'kde': {
-        package { $::networkmanager::package_kde:
+        package { $::networkmanager::params::package_openconnect_kde:
           ensure => $::networkmanager::package_ensure,
         }
       }

--- a/manifests/install/openconnect.pp
+++ b/manifests/install/openconnect.pp
@@ -7,8 +7,10 @@ class networkmanager::install::openconnect {
       'kde'   => $::networkmanager::params::package_openconnect_kde,
       default => $::networkmanager::package_gui_openconnect,
     }
-    package { $package:
-      ensure => $package_ensure,
+    if $package {
+      package { $package:
+        ensure => $package_ensure,
+      }
     }
   }
 }

--- a/manifests/install/openconnect.pp
+++ b/manifests/install/openconnect.pp
@@ -1,23 +1,14 @@
 # Class networkmanager::install::openconnect
 class networkmanager::install::openconnect {
-  include ::networkmanager
-
   if $::networkmanager::manage_packages {
-    package { $::networkmanager::params::package_openconnect:
-      ensure => $::networkmanager::package_ensure,
+    $package_ensure = pick($::networkmanager::version, $::networkmanager::package_ensure)
+    $package = $::networkmanager::gui ? {
+      'gnome' => $::networkmanager::params::package_openconnect_gnome,
+      'kde'   => $::networkmanager::params::package_openconnect_kde,
+      default => $::networkmanager::package_gui_openconnect,
     }
-    case $::networkmanager::gui {
-      'gnome': {
-        package { $::networkmanager::params::package_openconnect_gnome:
-          ensure => $::networkmanager::package_ensure,
-        }
-      }
-      'kde': {
-        package { $::networkmanager::params::package_openconnect_kde:
-          ensure => $::networkmanager::package_ensure,
-        }
-      }
-      default: {}
+    package { $package:
+      ensure => $package_ensure,
     }
   }
 }

--- a/manifests/install/openvpn.pp
+++ b/manifests/install/openvpn.pp
@@ -7,8 +7,10 @@ class networkmanager::install::openvpn {
       'kde'   => $::networkmanager::params::package_openvpn_kde,
       default => $::networkmanager::package_gui_openvpn,
     }
-    package { $package:
-      ensure => $package_ensure,
+    if $package {
+      package { $package:
+        ensure => $package_ensure,
+      }
     }
   }
 }

--- a/manifests/install/openvpn.pp
+++ b/manifests/install/openvpn.pp
@@ -1,23 +1,14 @@
 # Class networkmanager::install::openvpn
 class networkmanager::install::openvpn {
-  include ::networkmanager
-
   if $::networkmanager::manage_packages {
-    package { $::networkmanager::params::package_openvpn:
-      ensure => $::networkmanager::package_ensure,
+    $package_ensure = pick($::networkmanager::version, $::networkmanager::package_ensure)
+    $package = $::networkmanager::gui ? {
+      'gnome' => $::networkmanager::params::package_openvpn_gnome,
+      'kde'   => $::networkmanager::params::package_openvpn_kde,
+      default => $::networkmanager::package_gui_openvpn,
     }
-    case $::networkmanager::gui {
-      'gnome': {
-        package { $::networkmanager::params::package_openvpn_gnome:
-          ensure => $::networkmanager::package_ensure,
-        }
-      }
-      'kde': {
-        package { $::networkmanager::params::package_openvpn_kde:
-          ensure => $::networkmanager::package_ensure,
-        }
-      }
-      default: {}
+    package { $package:
+      ensure => $package_ensure,
     }
   }
 }

--- a/manifests/install/openvpn.pp
+++ b/manifests/install/openvpn.pp
@@ -1,19 +1,19 @@
-# Class networkmanager::install
-class networkmanager::install {
+# Class networkmanager::install::openvpn
+class networkmanager::install::openvpn {
   include ::networkmanager
 
   if $::networkmanager::manage_packages {
-    package { $::networkmanager::package:
+    package { $::networkmanager::params::package_openvpn:
       ensure => $::networkmanager::package_ensure,
     }
     case $::networkmanager::gui {
       'gnome': {
-        package { $::networkmanager::package_gnome:
+        package { $::networkmanager::params::package_openvpn_gnome:
           ensure => $::networkmanager::package_ensure,
         }
       }
       'kde': {
-        package { $::networkmanager::package_kde:
+        package { $::networkmanager::params::package_openvpn_kde:
           ensure => $::networkmanager::package_ensure,
         }
       }

--- a/manifests/install/wifi.pp
+++ b/manifests/install/wifi.pp
@@ -1,10 +1,9 @@
 # Class networkmanager::install::wifi
 class networkmanager::install::wifi {
-  include ::networkmanager
-
   if $::networkmanager::manage_packages {
+    $package_ensure = pick($::networkmanager::version, $::networkmanager::package_ensure)
     package { $::networkmanager::params::package_wifi:
-      ensure => $::networkmanager::package_ensure,
+      ensure => $package_ensure,
     }
   }
 }

--- a/manifests/install/wifi.pp
+++ b/manifests/install/wifi.pp
@@ -1,0 +1,10 @@
+# Class networkmanager::install::wifi
+class networkmanager::install::wifi {
+  include ::networkmanager
+
+  if $::networkmanager::manage_packages {
+    package { $::networkmanager::params::package_wifi:
+      ensure => $::networkmanager::package_ensure,
+    }
+  }
+}

--- a/manifests/install/wifi.pp
+++ b/manifests/install/wifi.pp
@@ -2,8 +2,10 @@
 class networkmanager::install::wifi {
   if $::networkmanager::manage_packages {
     $package_ensure = pick($::networkmanager::version, $::networkmanager::package_ensure)
-    package { $::networkmanager::params::package_wifi:
-      ensure => $package_ensure,
+    if $::networkmanager::params::package_wifi {
+      package { $::networkmanager::params::package_wifi:
+        ensure => $package_ensure,
+      }
     }
   }
 }

--- a/manifests/openconnect.pp
+++ b/manifests/openconnect.pp
@@ -1,11 +1,10 @@
-# See README.md for details.
+#Define networkmanager::openconnect
 define networkmanager::openconnect (
   $user,
   $gateway,
   $authtype,
   $xmlconfig,
-  $uuid          = regsubst(
-    md5($name), '^(.{8})(.{4})(.{4})(.{4})(.{12})$', '\1-\2-\3-\4-\5'),
+  $uuid          = regsubst(md5($name), '^(.{8})(.{4})(.{4})(.{4})(.{12})$', '\1-\2-\3-\4-\5'),
   $ensure        = 'present',
   $id            = $name,
   $autoconnect   = false,
@@ -14,20 +13,12 @@ define networkmanager::openconnect (
   $never_default = true,
 ) {
 
-  Class['networkmanager::install'] -> Networkmanager::Openconnect[$title]
+  include ::networkmanager::install::openconnect
 
-  ensure_resource(
-    'package', 'network-manager-openconnect', { ensure => present, }
-  )
+  Class['networkmanager::install::openconnect'] ->
+  Networkmanager::Openconnect[$title] ~>
+  Class['networkmanager::service']
 
-  case $::networkmanager::gui {
-    'gnome': {
-      ensure_resource(
-        'package', 'network-manager-openconnect-gnome', { ensure => present, }
-      )
-    }
-    default: {}
-  }
 
   file { "/etc/NetworkManager/system-connections/${name}":
     ensure  => $ensure,

--- a/manifests/openconnect.pp
+++ b/manifests/openconnect.pp
@@ -13,6 +13,7 @@ define networkmanager::openconnect (
   $never_default = true,
 ) {
 
+  include ::networkmanager
   include ::networkmanager::install::openconnect
 
   Class['networkmanager::install::openconnect'] ->

--- a/manifests/openvpn.pp
+++ b/manifests/openvpn.pp
@@ -1,21 +1,22 @@
 # Define networkmanager::openvpn
 define networkmanager::openvpn (
-  $remote,                  # use "vpn1.example.com:port:proto, vpn2.example.com:port:proto" syntax
-  $ca,                      # /path/to/ca.crt
-  $systemloginuser = undef, # username that owns the vpn connection profile
-  $vpnloginuser    = undef, # login to the vpn with this username
+  $remote,
+  $ca,
+  $user            = undef,
+  $username        = undef,
+  $permitted_user  = undef,
   $remote_random   = false,
-  $connection_type = 'tls', # can be 'tls', 'password-tls' or 'password'
-  $hmac            = undef, # this is the openvpn auth parameter
+  $connection_type = 'tls',
+  $hmac            = undef,
   $cipher          = undef,
   $dev_type        = undef,
-  $cert            = undef, # /path/to/cert.crt
-  $key             = undef, # /path/to/cert.key
+  $cert            = undef,
+  $key             = undef,
   $cert_pass_flags = undef,
-  $password_flags  = undef, # 0 = saved, 2 = always-ask, 4 = not-required
+  $password_flags  = undef,
   $comp_lzo        = false,
-  $ta              = undef, # /path/to/tlsauth.key
-  $ta_dir          = undef, # tlsauth key direction - must be 0 or 1
+  $ta              = undef,
+  $ta_dir          = undef,
   $uuid            = regsubst(md5($name), '^(.{8})(.{4})(.{4})(.{4})(.{12})$', '\1-\2-\3-\4-\5'),
   $ensure          = 'present',
   $id              = $name,
@@ -32,6 +33,12 @@ define networkmanager::openvpn (
   Class['networkmanager::install::openvpn'] ->
   Networkmanager::Openvpn[$title] ~>
   Class['networkmanager::service']
+
+  if $user {
+    warning('Define ::networkmanager: parameter $user has been deprecated and replaced with $username and $permitted_user.')
+  }
+  $_permitted_user = pick($user, $permitted_user)
+  $_username = pick($user, $_username)
 
   file { "/etc/NetworkManager/system-connections/${name}":
     ensure  => $ensure,

--- a/manifests/openvpn.pp
+++ b/manifests/openvpn.pp
@@ -1,38 +1,37 @@
-# See README.md for details.
+# Define networkmanager::openvpn
 define networkmanager::openvpn (
-  $user,
-  $ta_dir,
-  $connection_type,
-  $password_flags,
-  $remote,
-  $comp_lzo,
-  $ca,
-  $ta,
-  $uuid          = regsubst(
-    md5($name), '^(.{8})(.{4})(.{4})(.{4})(.{12})$', '\1-\2-\3-\4-\5'),
-  $ensure        = 'present',
-  $id            = $name,
-  $autoconnect   = false,
-  $ipv4_method   = 'auto',
-  $never_default = true,
-  $routes        = undef,
-  $dns = undef,
+  $remote,                  # use "vpn1.example.com:port:proto, vpn2.example.com:port:proto" syntax
+  $ca,                      # /path/to/ca.crt
+  $systemloginuser = undef, # username that owns the vpn connection profile
+  $vpnloginuser    = undef, # login to the vpn with this username
+  $remote_random   = false,
+  $connection_type = 'tls', # can be 'tls', 'password-tls' or 'password'
+  $hmac            = undef, # this is the openvpn auth parameter
+  $cipher          = undef,
+  $dev_type        = undef,
+  $cert            = undef, # /path/to/cert.crt
+  $key             = undef, # /path/to/cert.key
+  $cert_pass_flags = undef,
+  $password_flags  = undef, # 0 = saved, 2 = always-ask, 4 = not-required
+  $comp_lzo        = false,
+  $ta              = undef, # /path/to/tlsauth.key
+  $ta_dir          = undef, # tlsauth key direction - must be 0 or 1
+  $uuid            = regsubst(md5($name), '^(.{8})(.{4})(.{4})(.{4})(.{12})$', '\1-\2-\3-\4-\5'),
+  $ensure          = 'present',
+  $id              = $name,
+  $autoconnect     = false,
+  $ipv4_method     = 'auto',
+  $never_default   = undef,
+  $routes          = undef,
+  $dns             = undef,
+  $dns_search      = undef,
 ) {
 
-  Class['networkmanager::install'] -> Networkmanager::Openvpn[$title]
+  include ::networkmanager::install::openvpn
 
-  ensure_resource(
-    'package', 'network-manager-openvpn', { ensure => present, }
-  )
-
-  case $::networkmanager::gui {
-    'gnome': {
-      ensure_resource(
-        'package', 'network-manager-openvpn-gnome', { ensure => present, }
-      )
-    }
-    default: {}
-  }
+  Class['networkmanager::install::openvpn'] ->
+  Networkmanager::Openvpn[$title] ~>
+  Class['networkmanager::service']
 
   file { "/etc/NetworkManager/system-connections/${name}":
     ensure  => $ensure,

--- a/manifests/openvpn.pp
+++ b/manifests/openvpn.pp
@@ -28,6 +28,7 @@ define networkmanager::openvpn (
   $dns_search      = undef,
 ) {
 
+  include ::networkmanager
   include ::networkmanager::install::openvpn
 
   Class['networkmanager::install::openvpn'] ->
@@ -37,8 +38,8 @@ define networkmanager::openvpn (
   if $user {
     warning('Define ::networkmanager: parameter $user has been deprecated and replaced with $username and $permitted_user.')
   }
-  $_permitted_user = pick($user, $permitted_user)
-  $_username = pick($user, $_username)
+  $_permitted_user = pick_default($user, $permitted_user)
+  $_username = pick_default($user, $_username)
 
   file { "/etc/NetworkManager/system-connections/${name}":
     ensure  => $ensure,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,11 +1,17 @@
 # Class networkmanager::params
 class networkmanager::params {
+  $version = undef
+  $enable = undef
+  $start = undef
+  $gui = undef
   $package_ensure = 'present'
   $manage_packages = true
+  $package_gui = undef
+  $package_gui_openvpn = undef
+  $package_gui_openconnect = undef
   $manage_service = true
   $service_enable = true
   $service_ensure = 'running'
-  $gui = undef
   case $::osfamily {
     'Debian': {
       $package = 'network-manager'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,6 @@
 # Class networkmanager::params
 class networkmanager::params {
-  $ensure = 'present'
+  $package_ensure = 'present'
   $manage_packages = true
   $manage_service = true
   $service_enable = true
@@ -18,6 +18,7 @@ class networkmanager::params {
       $package_openvpn_kde = undef
       $package_openconnect_gnome = 'network-manager-openconnect-gnome'
       $package_openconnect_kde = undef
+      $service = 'network-manager'
     }
     'RedHat': {
       $package = 'NetworkManager'
@@ -30,6 +31,7 @@ class networkmanager::params {
       $package_openvpn_kde = 'kde-plasma-networkmanagement-openvpn'
       $package_openconnect_gnome = undef
       $package_openconnect_kde = 'kde-plasma-networkmanagement-openconnect'
+      $service = 'NetworkManager'
     }
     default: {
       fail("Unsupported osfamily ${::osfamily}")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,38 @@
+# Class networkmanager::params
+class networkmanager::params {
+  $ensure = 'present'
+  $manage_packages = true
+  $manage_service = true
+  $service_enable = true
+  $service_ensure = 'running'
+  $gui = undef
+  case $::osfamily {
+    'Debian': {
+      $package = 'network-manager'
+      $package_openvpn = 'network-manager-openvpn'
+      $package_openconnect = 'network-manager-openconnect'
+      $package_wifi = undef
+      $package_gnome = 'network-manager-gnome'
+      $package_kde = 'plasma-nm'
+      $package_openvpn_gnome = 'network-manager-openvpn-gnome'
+      $package_openvpn_kde = undef
+      $package_openconnect_gnome = 'network-manager-openconnect-gnome'
+      $package_openconnect_kde = undef
+    }
+    'RedHat': {
+      $package = 'NetworkManager'
+      $package_openvpn = 'NetworkManager-openvpn'
+      $package_openconnect = 'NetworkManager-openconnect'
+      $package_wifi = 'NetworkManager-wifi'
+      $package_gnome = 'NetworkManager-openvpn-gnome'
+      $package_kde = 'kde-plasma-networkmanagement'
+      $package_openvpn_gnome = 'NetworkManager-openvpn-gnome'
+      $package_openvpn_kde = 'kde-plasma-networkmanagement-openvpn'
+      $package_openconnect_gnome = undef
+      $package_openconnect_kde = 'kde-plasma-networkmanagement-openconnect'
+    }
+    default: {
+      fail("Unsupported osfamily ${::osfamily}")
+    }
+  }
+}

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,14 +1,17 @@
 # Class networkmanager::service
 class networkmanager::service {
-  include ::networkmanager
-
   if $::networkmanager::manage_service {
-    service { $::networkmanager::params::service:
-      ensure => $::networkmanager::service_ensure,
-      enable => $::networkmanager::service_enable,
+    $service_enable = pick($::networkmanager::enable, $::networkmanager::service_enable)
+    $service_ensure = $::networkmanager::start ? {
+      true    => 'running',
+      false   => 'stopped',
+      default => $::networkmanager::service_ensure,
+    }
+    service { $::networkmanager::service:
+      ensure => $service_ensure,
+      enable => $service_enable,
     }
   }
-
   exec {'reload nm configuration':
     name        => '/usr/bin/nmcli connection reload',
     refreshonly => true,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,11 +1,11 @@
+# Class networkmanager::service
 class networkmanager::service {
-  $ensure = $::networkmanager::start ? {
-    true    => running,
-    default => stopped,
-  }
+  include ::networkmanager
 
-  service { 'network-manager':
-    ensure => $ensure,
-    enable => $::networkmanager::enable,
+  if $::networkmanager::manage_service {
+    service { $::networkmanager::params::service:
+      ensure => $::networkmanager::service_ensure,
+      enable => $::networkmanager::service_enable,
+    }
   }
 }

--- a/manifests/wifi.pp
+++ b/manifests/wifi.pp
@@ -7,7 +7,7 @@ define networkmanager::wifi (
   $password_raw_flags,
   $uuid                   = regsubst(
     md5($name), '^(.{8})(.{4})(.{4})(.{4})(.{12})$', '\1-\2-\3-\4-\5'),
-  $ensure                 = present,
+  $ensure                 = 'present',
   $mode                   = 'infrastructure',
   $mac_address            = undef,
   $autoconnect            = true,
@@ -37,7 +37,7 @@ define networkmanager::wifi (
 
   if $ensure == 'present' {
     Ini_setting {
-      ensure  => present,
+      ensure  => 'present',
       path    => "/etc/NetworkManager/system-connections/${name}",
       notify  => Exec['reload nm configuration'],
     }
@@ -148,7 +148,7 @@ define networkmanager::wifi (
 
   if ( $eap =~ /^tls|^ttls|^peap/ ) {
     file { "${directory}/org.gnome.nm-applet.eap.${uuid}.gschema.xml":
-      ensure  => file,
+      ensure  => 'file',
       content => template('networkmanager/org.gnome.nm-applet.eap.gschema.xml.erb'),
     } ~>
     exec { "Compile modifications for ${uuid}":

--- a/manifests/wifi.pp
+++ b/manifests/wifi.pp
@@ -1,12 +1,11 @@
-# See README.md for details.
+# Define networkmanager::wifi
 define networkmanager::wifi (
   $user,
   $ssid,
   $eap,
   $phase2_auth,
   $password_raw_flags,
-  $uuid               = regsubst(
-    md5($name), '^(.{8})(.{4})(.{4})(.{4})(.{12})$', '\1-\2-\3-\4-\5'),
+  $uuid               = regsubst(md5($name), '^(.{8})(.{4})(.{4})(.{4})(.{12})$', '\1-\2-\3-\4-\5'),
   $ensure             = present,
   $mode               = 'infrastructure',
   $mac_address        = undef,
@@ -19,7 +18,11 @@ define networkmanager::wifi (
   $auth_alg           = 'open',
 ) {
 
-  Class['networkmanager::install'] -> Networkmanager::Wifi[$title]
+  include ::networkmanager::install::wifi
+
+  Class['networkmanager::install::wifi'] ->
+  Networkmanager::Wifi[$title] ~>
+  Class['networkmanager::service']
 
   file { "/etc/NetworkManager/system-connections/${name}":
     ensure => $ensure,

--- a/manifests/wifi.pp
+++ b/manifests/wifi.pp
@@ -22,6 +22,7 @@ define networkmanager::wifi (
   $ignore_phase2_ca_cert  = false,
 ) {
 
+  include ::networkmanager
   include ::networkmanager::install::wifi
 
   Class['networkmanager::install::wifi'] ->

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=3.2.0 <5.0.0"
+      "version_requirement": ">=4.10.0 <5.0.0"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "camptocamp-networkmanager",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "author": "Camptocamp",
   "summary": "Puppet NetworkManager module",
   "license": "Apache-2.0",

--- a/spec/classes/networkmanager_spec.rb
+++ b/spec/classes/networkmanager_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe 'networkmanager' do
-
-  context 'without parameters' do
-    it { should compile.with_all_deps }
+  on_supported_os.each do |os, os_facts|
+    context 'without parameters' do
+      it { should compile.with_all_deps }
+    end
   end
-
 end
 

--- a/templates/openvpn.erb
+++ b/templates/openvpn.erb
@@ -2,14 +2,14 @@
 id=<%= @id %>
 uuid=<%= @uuid %>
 type=vpn
-<% if @systemloginuser != :undef -%>
-permissions=user:<%= @systemloginuser %>:;
-<% else -%>
+<% if @systemloginuser.empty? -%>
 permissions=
+<% else -%>
+permissions=user:<%= @systemloginuser %>:;
 <% end -%>
 <% if @autoconnect -%>
 autoconnect=true
-<% elsif @autoconnect != :undef -%>
+<% elsif !@autoconnect.empty? -%>
 autoconnect=false
 <% end -%>
 
@@ -19,68 +19,68 @@ remote=<%= @remote %>
 connection-type=<%= @connection_type %>
 <% if @remote_random -%>
 remote-random=yes
-<% elsif @remote_random != :undef -%>
+<% elsif !@remote_random.empty? -%>
 remote-random=no
 <% end -%>
 <% if @connection_type.include? "tls" -%>
-<%   if @cert != :undef -%>
+<%   if !@cert.empty? -%>
 cert=<%= @cert %>
 <%   end -%>
-<%   if @key != :undef -%>
+<%   if !@key.empty? -%>
 key=<%= @key %>
 <%   end -%>
-<%   if @cert_pass_flags != :undef -%>
+<%   if !@cert_pass_flags.empty? -%>
 cert-pass-flags=<%= @cert_pass_flags %>
 <%   else -%>
 cert-pass-flags=0
 <%   end %>
 <% end -%>
 <% if @connection_type.include? "password" -%>
-<%   if @vpnloginuser != :undef -%>
+<%   if !@vpnloginuser.empty? -%>
 username=<%= @vpnloginuser %>
 <%   end -%>
-<%   if @password_flags != :undef -%>
+<%   if !@password_flags.empty? -%>
 password-flags=<%= @password_flags %>
 <%   else -%>
 password-flags=2
 <%   end -%>
 <% end -%>
-<% if @hmac != :undef -%>
+<% if !@hmac.empty? -%>
 auth=<%= @hmac %>
 <% end -%>
-<% if @cipher != :undef -%>
+<% if !@cipher.empty? -%>
 cipher=<%= @cipher %>
 <% end -%>
 <% if @comp_lzo -%>
 comp-lzo=yes
-<% elsif @comp_lzo != :undef -%>
+<% elsif !@comp_lzo.empty? -%>
 comp-lzo=no
 <% end -%>
-<% if @ca != :undef -%>
+<% if !@ca.empty? -%>
 ca=<%= @ca %>
 <% end -%>
-<% if @ta != :undef -%>
+<% if !@ta.empty? -%>
 ta=<%= @ta %>
 <% end -%>
-<% if @ta_dir != :undef -%>
+<% if !@ta_dir.empty? -%>
 ta-dir=<%= @ta_dir %>
 <% end -%>
-<% if @dev_type != :undef -%>
+<% if !@dev_type.empty? -%>
 dev-type=<%= @dev_type %>
 <% end -%>
 
 [ipv4]
 method=<%= @ipv4_method %>
-<% if @routes != :undef -%>
+<% if !@routes.empty? -%>
 routes1=<%= @routes %>
 <% end -%>
-<% if @dns != :undef -%>
+<% if !@dns.empty? -%>
 dns=<%= @dns %>
 <% end -%>
-<% if @dns_search != :undef -%>
+<% if !@dns_search.empty? -%>
 dns-search=<%= @dns_search %>
 <% end -%>
-<% if @never_default != :undef -%>
+<% if !@never_default.empty? -%>
 never-default=<%= @never_default %>
 <% end -%>
 

--- a/templates/openvpn.erb
+++ b/templates/openvpn.erb
@@ -2,10 +2,10 @@
 id=<%= @id %>
 uuid=<%= @uuid %>
 type=vpn
-<% if @systemloginuser.nil? -%>
+<% if @_permitted_user.nil? -%>
 permissions=
 <% else -%>
-permissions=user:<%= @systemloginuser %>:;
+permissions=user:<%= @_permitted_user %>:;
 <% end -%>
 <% if @autoconnect -%>
 autoconnect=true
@@ -36,8 +36,8 @@ cert-pass-flags=0
 <%   end %>
 <% end -%>
 <% if @connection_type.include? "password" -%>
-<%   if !@vpnloginuser.nil? -%>
-username=<%= @vpnloginuser %>
+<%   if !@_username.nil? -%>
+username=<%= @_username %>
 <%   end -%>
 <%   if !@password_flags.nil? -%>
 password-flags=<%= @password_flags %>

--- a/templates/openvpn.erb
+++ b/templates/openvpn.erb
@@ -2,26 +2,87 @@
 id=<%= @id %>
 uuid=<%= @uuid %>
 type=vpn
-permissions=user:<%= @user %>:;
-autoconnect=<%= @autoconnect %>
+<% if @systemloginuser != :undef -%>
+permissions=user:<%= @systemloginuser %>:;
+<% else -%>
+permissions=
+<% end -%>
+<% if @autoconnect -%>
+autoconnect=true
+<% elsif @autoconnect != :undef -%>
+autoconnect=false
+<% end -%>
 
 [vpn]
 service-type=org.freedesktop.NetworkManager.openvpn
-ta-dir=<%= @ta_dir %>
-connection-type=<%= @connection_type %>
-password-flags=<%= @password_flags %>
 remote=<%= @remote %>
-comp-lzo=<%= @comp_lzo %>
-username=<%= @user %>
+connection-type=<%= @connection_type %>
+<% if @remote_random -%>
+remote-random=yes
+<% elsif @remote_random != :undef -%>
+remote-random=no
+<% end -%>
+<% if @connection_type.include? "tls" -%>
+<%   if @cert != :undef -%>
+cert=<%= @cert %>
+<%   end -%>
+<%   if @key != :undef -%>
+key=<%= @key %>
+<%   end -%>
+<%   if @cert_pass_flags != :undef -%>
+cert-pass-flags=<%= @cert_pass_flags %>
+<%   else -%>
+cert-pass-flags=0
+<%   end %>
+<% end -%>
+<% if @connection_type.include? "password" -%>
+<%   if @vpnloginuser != :undef -%>
+username=<%= @vpnloginuser %>
+<%   end -%>
+<%   if @password_flags != :undef -%>
+password-flags=<%= @password_flags %>
+<%   else -%>
+password-flags=2
+<%   end -%>
+<% end -%>
+<% if @hmac != :undef -%>
+auth=<%= @hmac %>
+<% end -%>
+<% if @cipher != :undef -%>
+cipher=<%= @cipher %>
+<% end -%>
+<% if @comp_lzo -%>
+comp-lzo=yes
+<% elsif @comp_lzo != :undef -%>
+comp-lzo=no
+<% end -%>
+<% if @ca != :undef -%>
 ca=<%= @ca %>
+<% end -%>
+<% if @ta != :undef -%>
 ta=<%= @ta %>
+<% end -%>
+<% if @ta_dir != :undef -%>
+ta-dir=<%= @ta_dir %>
+<% end -%>
+<% if @dev_type != :undef -%>
+dev-type=<%= @dev_type %>
+<% end -%>
 
 [ipv4]
-<% if @routes -%>
+method=<%= @ipv4_method %>
+<% if @routes != :undef -%>
 routes1=<%= @routes %>
 <% end -%>
-<% if @dns -%>
+<% if @dns != :undef -%>
 dns=<%= @dns %>
 <% end -%>
-method=<%= @ipv4_method %>
+<% if @dns_search != :undef -%>
+dns-search=<%= @dns_search %>
+<% end -%>
+<% if @never_default != :undef -%>
 never-default=<%= @never_default %>
+<% end -%>
+
+[ipv6]
+method=ignore

--- a/templates/openvpn.erb
+++ b/templates/openvpn.erb
@@ -2,7 +2,7 @@
 id=<%= @id %>
 uuid=<%= @uuid %>
 type=vpn
-<% if @_permitted_user.nil? -%>
+<% if @_permitted_user.nil? or @_permitted_user.eql? "" -%>
 permissions=
 <% else -%>
 permissions=user:<%= @_permitted_user %>:;

--- a/templates/openvpn.erb
+++ b/templates/openvpn.erb
@@ -2,14 +2,14 @@
 id=<%= @id %>
 uuid=<%= @uuid %>
 type=vpn
-<% if @systemloginuser.empty? -%>
+<% if @systemloginuser.nil? -%>
 permissions=
 <% else -%>
 permissions=user:<%= @systemloginuser %>:;
 <% end -%>
 <% if @autoconnect -%>
 autoconnect=true
-<% elsif !@autoconnect.empty? -%>
+<% else -%>
 autoconnect=false
 <% end -%>
 
@@ -19,68 +19,70 @@ remote=<%= @remote %>
 connection-type=<%= @connection_type %>
 <% if @remote_random -%>
 remote-random=yes
-<% elsif !@remote_random.empty? -%>
+<% elsif !@remote_random.nil? -%>
 remote-random=no
 <% end -%>
 <% if @connection_type.include? "tls" -%>
-<%   if !@cert.empty? -%>
+<%   if !@cert.nil? -%>
 cert=<%= @cert %>
 <%   end -%>
-<%   if !@key.empty? -%>
+<%   if !@key.nil? -%>
 key=<%= @key %>
 <%   end -%>
-<%   if !@cert_pass_flags.empty? -%>
+<%   if !@cert_pass_flags.nil? -%>
 cert-pass-flags=<%= @cert_pass_flags %>
 <%   else -%>
 cert-pass-flags=0
 <%   end %>
 <% end -%>
 <% if @connection_type.include? "password" -%>
-<%   if !@vpnloginuser.empty? -%>
+<%   if !@vpnloginuser.nil? -%>
 username=<%= @vpnloginuser %>
 <%   end -%>
-<%   if !@password_flags.empty? -%>
+<%   if !@password_flags.nil? -%>
 password-flags=<%= @password_flags %>
 <%   else -%>
 password-flags=2
 <%   end -%>
 <% end -%>
-<% if !@hmac.empty? -%>
+<% if !@hmac.nil? -%>
 auth=<%= @hmac %>
 <% end -%>
-<% if !@cipher.empty? -%>
+<% if !@cipher.nil? -%>
 cipher=<%= @cipher %>
 <% end -%>
 <% if @comp_lzo -%>
 comp-lzo=yes
-<% elsif !@comp_lzo.empty? -%>
+<% elsif !@comp_lzo.nil? -%>
 comp-lzo=no
 <% end -%>
-<% if !@ca.empty? -%>
+<% if !@ca.nil? -%>
 ca=<%= @ca %>
 <% end -%>
-<% if !@ta.empty? -%>
+<% if !@ta.nil? -%>
 ta=<%= @ta %>
 <% end -%>
-<% if !@ta_dir.empty? -%>
+<% if !@ta_dir.nil? -%>
 ta-dir=<%= @ta_dir %>
 <% end -%>
-<% if !@dev_type.empty? -%>
+<% if !@dev_type.nil? -%>
 dev-type=<%= @dev_type %>
 <% end -%>
 
 [ipv4]
 method=<%= @ipv4_method %>
-<% if !@routes.empty? -%>
+<% if !@routes.nil? -%>
 routes1=<%= @routes %>
 <% end -%>
-<% if !@dns.empty? -%>
+<% if !@dns.nil? -%>
 dns=<%= @dns %>
 <% end -%>
-<% if !@dns_search.empty? -%>
+<% if !@dns_search.nil? -%>
 dns-search=<%= @dns_search %>
+<% else -%>
+dns-search=
 <% end -%>
-<% if !@never_default.empty? -%>
+<% if !@never_default.nil? -%>
 never-default=<%= @never_default %>
 <% end -%>
 


### PR DESCRIPTION
This is still a work in progress, don't merge yet.
- Missing documentation for new settings in `networkmanager::openvpn`
- `networkmanager::openvpn::user` removal not backwards-compatible

Creating the PR to start the conversation about these proposed changes and gauge whether acceptance is likely or if I should just permanently maintain a separate fork for openvpn on EL.

UPDATE:
- README now documents new settings in `networkmanager::openvpn`
- `user` parameter to `networkmanager::openvpn` re-introduced (but deprecated) to maintain backward compatibility.

I have no idea how to fix the tests, but these changes have been tested on CentOS 7 and have been running in production for almost a year.
